### PR TITLE
Widen about me and publication content

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_PATH: "vendor/bundle"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,7 +13,7 @@
     <![endif]-->
     {% include head-custom.html %}
   </head>
-  <body>
+  <body class="{% if page.full-width %}wide-content{% endif %}">
     <div class="wrapper">
       <header>
         <h1><a href="{{ "/" | absolute_url }}">{{ site.title | default: site.github.repository_name }}</a></h1>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -2,3 +2,21 @@
 ---
 
 @import "jekyll-theme-minimal";
+
+// Expand main content width when page sets `full-width: true` in front matter
+body.wide-content {
+  .wrapper {
+    width: 1100px;
+  }
+  section {
+    width: 800px;
+  }
+}
+
+// Keep responsive behavior similar to the theme below 960px
+@media print, screen and (max-width: 960px) {
+  body.wide-content {
+    .wrapper { width: auto; }
+    section { width: auto; }
+  }
+}


### PR DESCRIPTION
Add `full-width` page flag and CSS to allow specific pages to have wider content.

---
<a href="https://cursor.com/background-agent?bcId=bc-a35526f8-0817-4c6d-9504-823c2a439c72">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a35526f8-0817-4c6d-9504-823c2a439c72">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

